### PR TITLE
Fix N+1 and O(n²) query patterns across controllers and models

### DIFF
--- a/controllers/album.rb
+++ b/controllers/album.rb
@@ -3,7 +3,7 @@ require "base64"
 
 class AlbumController < BaseController
   get '/' do
-    @albums = Album.order(:timestamp)
+    @albums = Album.eager(:member, :party).order(:timestamp)
     haml :albums
   end
 
@@ -11,7 +11,7 @@ class AlbumController < BaseController
     @photo = Photo[id]
     halt 404 unless @photo
     @prev_id, @next_id = @photo.surrounding_ids
-    @comments = @photo.comments
+    @comments = @photo.comments_dataset.eager(:member).all
     haml :photo
   end
 

--- a/controllers/home.rb
+++ b/controllers/home.rb
@@ -2,7 +2,7 @@ require './controllers/base'
 
 class HomeController < BaseController
   get '/' do
-    @parties = Party.where(Sequel.lit("NOW() < date + 1")).order(:attendance_deadline).all
+    @parties = Party.eager(:attendances).where(Sequel.lit("NOW() < date + 1")).order(:attendance_deadline).all
     haml :home
   end
 

--- a/controllers/statistics.rb
+++ b/controllers/statistics.rb
@@ -5,15 +5,18 @@ class StatisticsController < BaseController
   end
 
   get '/data/studied' do
-    Member.all.group_by(&:studied).map {|k,v| {:name=> k, :quantity => v.length}}.to_json
+    DB[:members].group_and_count(:studied).all
+      .map { |r| { name: r[:studied], quantity: r[:count] } }.to_json
   end
 
   get '/data/started' do
-    Member.all.group_by(&:started).map {|k,v| {:name=> k, :quantity => v.length}}.to_json
+    DB[:members].group_and_count(:started).all
+      .map { |r| { name: r[:started], quantity: r[:count] } }.to_json
   end
 
   get '/data/city' do
-    Member.all.group_by(&:city).map {|k,v| {:name=> k, :quantity => v.length}}.to_json
+    DB[:members].group_and_count(:city).all
+      .map { |r| { name: r[:city], quantity: r[:count] } }.to_json
   end
 
   helpers do

--- a/views/party.haml
+++ b/views/party.haml
@@ -59,7 +59,7 @@
     %tbody
       - @attendances.each do |a|
         %tr
-          %td= a.member_previus_attendanceise
+          %td= @prior_counts[a.member_id] || 0
           %td
             %a{href: "/member/#{a[:member_id]}"}= a.member_name
             -if a.right_foot


### PR DESCRIPTION
- Photo#surrounding_ids: 2 indexed queries instead of full table load
- Attendance#member_previus_attendanceise: SQL COUNT instead of O(n²) Ruby
- Party#purchases_highchart: eager load articles, hash lookup instead of linear search
- Member#parties: SQL JOIN instead of loading all attendances
- Member#attendance: dataset query instead of loading all attendances
- Party controller: eager load associations, batch-compute prior counts
- Album controller: eager load :member, :party, and comments :member
- Home controller: eager load :attendances for is_attending? cache
- Statistics controller: SQL GROUP BY instead of loading all members