### PR TITLE
Use presigned S3 URLs for profile pictures (1h expiry)

### DIFF
--- a/models.rb
+++ b/models.rb
@@ -35,12 +35,19 @@ class Member < Sequel::Model
     attendances_dataset.where(party_id: party_id).first || Attendance.new
   end
 
+  def s3
+    @s3_client ||= Aws::S3::Resource.new(region: "eu-west-1")
+    @s3 ||= @s3_client.bucket("avnsp")
+  end
+
   def profile_picture_cdn
-    "https://#{CF_DOMAIN}/#{profile_picture}"
+    return unless profile_picture
+    s3.object(profile_picture).presigned_url(:get, expires_in: 3600)
   end
 
   def thumb_cdn
-    "https://#{CF_DOMAIN}/#{profile_picture}.thumb"
+    return unless profile_picture
+    s3.object("#{profile_picture}.thumb").presigned_url(:get, expires_in: 3600)
   end
 
   def balance

--- a/test/models/member_test.rb
+++ b/test/models/member_test.rb
@@ -70,11 +70,25 @@ class MemberTest < Minitest::Test
 
   def test_profile_picture_cdn
     m = create_member(profile_picture: "photos/profile.jpg")
-    assert_equal "https://www.academian.se/photos/profile.jpg", m.profile_picture_cdn
+    url = m.profile_picture_cdn
+    assert_match %r{^https://avnsp\.s3\.eu-west-1\.amazonaws\.com/photos/profile\.jpg\?}, url
+    assert_match(/X-Amz-Expires=3600/, url)
+  end
+
+  def test_profile_picture_cdn_nil_when_no_picture
+    m = create_member(profile_picture: nil)
+    assert_nil m.profile_picture_cdn
   end
 
   def test_thumb_cdn
     m = create_member(profile_picture: "photos/profile.jpg")
-    assert_equal "https://www.academian.se/photos/profile.jpg.thumb", m.thumb_cdn
+    url = m.thumb_cdn
+    assert_match %r{^https://avnsp\.s3\.eu-west-1\.amazonaws\.com/photos/profile\.jpg\.thumb\?}, url
+    assert_match(/X-Amz-Expires=3600/, url)
+  end
+
+  def test_thumb_cdn_nil_when_no_picture
+    m = create_member(profile_picture: nil)
+    assert_nil m.thumb_cdn
   end
 end


### PR DESCRIPTION
The S3 bucket is not publicly accessible, so profile picture URLs need to be presigned just like album photos (731e840). Also handle nil profile_picture gracefully.